### PR TITLE
removing stability stable-diffusion-xl-v1 - deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12486,6 +12486,126 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.18.tgz",
+      "integrity": "sha512-uJCEjutt5VeJ30jjrHV1VIHCsbMYnEqytQgvREx+DjURd/fmKy15NaVK4aR/u98S1LGTnjq35lRTnRyygglxoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.18.tgz",
+      "integrity": "sha512-IL6rU8vnBB+BAm6YSWZewc+qvdL1EaA+VhLQ6tlUc0xp+kkdxQrVqAnh8Zek1ccKHlTDFRyAft0e60gteYmQ4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.18.tgz",
+      "integrity": "sha512-RCaENbIZqKKqTlL8KNd+AZV/yAdCsovblOpYFp0OJ7ZxgLNbV5w23CUU1G5On+0fgafrsGcW+GdMKdFjaRwyYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.18.tgz",
+      "integrity": "sha512-3kmv8DlyhPRCEBM1Vavn8NjyXtMeQ49ID0Olr/Sut7pgzaQTo4h01S7Z8YNE0VtbowyuAL26ibcz0ka6xCTH5g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.18.tgz",
+      "integrity": "sha512-mliTfa8seVSpTbVEcKEXGjC18+TDII8ykW4a36au97spm9XMPqQTpdGPNBJ9RySSFw9/hLuaCMByluQIAnkzlw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.18.tgz",
+      "integrity": "sha512-J5g0UFPbAjKYmqS3Cy7l2fetFmWMY9Oao32eUsBPYohts26BdrMUyfCJnZFQkX9npYaHNDOWqZ6uV9hSDPw9NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.18.tgz",
+      "integrity": "sha512-Ynxuk4ZgIpdcN7d16ivJdjsDG1+3hTvK24Pp8DiDmIa2+A4CfhJSEHHVndCHok6rnLUzAZD+/UOKESQgTsAZGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.18.tgz",
+      "integrity": "sha512-dtRGMhiU9TN5nyhwzce+7c/4CCeykYS+ipY/4mIrGzJ71+7zNo55ZxCB7cAVuNqdwtYniFNR2c9OFQ6UdFIMcg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/lib/image-prompt-helper.ts
+++ b/src/lib/image-prompt-helper.ts
@@ -30,11 +30,6 @@ export const getImageModelPrompt = ({ modelId, messages, config }: GetModelPromp
           ...settings,
         },
       };
-    case "stability.stable-diffusion-xl-v1":
-      return {
-        text_prompts: messages.map((m) => ({ text: m.content })),
-        ...settings,
-      };
     case "stability.stable-image-core-v1:0":
     case "stability.stable-image-ultra-v1:0":
     case "stability.sd3-large-v1:0":
@@ -52,8 +47,6 @@ export const getImageModelResponse = (modelId: ImageModelId, response: any) => {
     case "amazon.titan-image-generator-v1":
     case "amazon.titan-image-generator-v2:0":
       return (response.images as []).map((imageData: any) => `![Image](data:image/png;base64,${imageData})`).join("\n");
-    case "stability.stable-diffusion-xl-v1":
-      return `![${response.result}](data:image/png;base64,${response.artifacts[0].base64})`;
     case "stability.stable-image-core-v1:0":
     case "stability.stable-image-ultra-v1:0":
     case "stability.sd3-large-v1:0":

--- a/src/lib/model/model.type.ts
+++ b/src/lib/model/model.type.ts
@@ -55,7 +55,6 @@ export type TextModelId =
 export type ImageModelId =
   | "amazon.titan-image-generator-v1"
   | "amazon.titan-image-generator-v2:0"
-  | "stability.stable-diffusion-xl-v1"
   | "stability.stable-image-core-v1:0"
   | "stability.sd3-large-v1:0"
   | "stability.stable-image-ultra-v1:0";

--- a/src/lib/model/models.ts
+++ b/src/lib/model/models.ts
@@ -9,7 +9,6 @@ import {
   mistralLargeConfig,
   openAiGpt4oConfig,
   openAiGpt4ominiConfig,
-  sdxlModelConfig,
   stabilityModelConfig,
   titanImageModelConfig,
   titanTextExpressConfig,
@@ -373,13 +372,6 @@ export const imageModels: ImageModel[] = [
     name: "Titan G1 V2",
     provider: "Amazon",
     config: titanImageModelConfig,
-  },
-  {
-    inputModalities: ["TEXT", "IMAGE"],
-    id: "stability.stable-diffusion-xl-v1",
-    name: "SDXL 1.0",
-    provider: "Stability AI",
-    config: sdxlModelConfig,
   },
   {
     provider: "Stability AI",


### PR DESCRIPTION
Removing support for `stability.stable-diffusion-xl-v1` as it's being deprecated

https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html