### PR TITLE
Add Llama 3.3 70b Instruct

### DIFF
--- a/src/lib/model/model.type.ts
+++ b/src/lib/model/model.type.ts
@@ -44,6 +44,7 @@ export type TextModelId =
   | "us.meta.llama3-2-3b-instruct-v1:0"
   | "us.meta.llama3-2-11b-instruct-v1:0"
   | "us.meta.llama3-2-90b-instruct-v1:0"
+  | "us.meta.llama3-3-70b-instruct-v1:0"
   | "mistral.mistral-7b-instruct-v0:2"
   | "mistral.mixtral-8x7b-instruct-v0:1"
   | "mistral.mistral-large-2407-v1:0"

--- a/src/lib/model/models.ts
+++ b/src/lib/model/models.ts
@@ -287,6 +287,18 @@ export const textModels: TextModel[] = [
     systemPromptSupport: true,
   },
   {
+    provider: "Meta",
+    id: "us.meta.llama3-3-70b-instruct-v1:0",
+    name: "Llama 3.3 70B Instruct",
+    region: "us-west-2",
+    inputCostPerToken: 0.00072 / 1e3,
+    outputCostPerToken: 0.00072 / 1e3,
+    inputModalities: ["TEXT"],
+    outputModalities: ["TEXT"],
+    config: llamaDefaultModelConfig,
+    systemPromptSupport: true,
+  },
+  {
     provider: "Mistral",
     id: "mistral.mistral-7b-instruct-v0:2",
     name: "Mistral 7B Instruct",


### PR DESCRIPTION
# Add Llama 3 70B Instruct Model Support

## Description
This PR introduces support for the Llama 3 70B Instruct model, enhancing our application's capabilities with state-of-the-art language model performance. (https://aws.amazon.com/about-aws/whats-new/2024/12/metas-llama-3-3-70b-model-amazon-bedrock/)

## Changes Made
- Added Llama 3 70B Instruct model configuration
- Implemented model-specific settings

## Key Features & Improvements
- Enhanced reasoning and instruction-following capabilities
- Improved code generation performance
- Better context understanding and response quality
- State-of-the-art performance at the 70B parameter scale

## Testing
- [x] Verified model loading and initialization
- [x] Tested inference with various text inputs

## Additional Notes
- To use this model, you must first request access through Amazon Bedrock.